### PR TITLE
Fix scorecard-action pin: no floating v2 tag

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2
+      - uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- \`ossf/scorecard-action\` doesn't publish a floating major tag (\`v2\`) like \`actions/checkout\`/\`actions/upload-artifact\`/\`codeql-action\` do — only exact patch tags (\`v2.0.0\`...\`v2.4.3\`). The workflow run on master failed with "Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`".
- Pin to the latest existing tag, \`v2.4.3\`, instead.

## Test plan
- [ ] Merge and confirm the Scorecard workflow run succeeds on `master`