### PR TITLE
Add changeset for npm provenance and dependency bumps

### DIFF
--- a/.changeset/npm-provenance.md
+++ b/.changeset/npm-provenance.md
@@ -1,0 +1,6 @@
+---
+"@ekz/packer": patch
+"@ekz/eslint-config-packer": patch
+---
+
+Publish with npm provenance attestations, so releases are verifiably built from this repository's GitHub Actions workflow. Also upgrades webpack, webpack-cli, and postcss-preset-env to their latest patch/minor releases.


### PR DESCRIPTION
Adds a patch changeset for both packages so the next release actually ships the `--provenance` publishing added in the Scorecard hardening work — until a release happens, that flag has no effect and npm still shows no provenance attestation for 1.0.0.

The dependency bumps merged since 1.0.0 (webpack, webpack-cli, postcss-preset-env) are caret-range floor moves only, so they carry no consumer-visible change on their own; they're mentioned in the changeset for completeness.