### PR TITLE
Merge caller resolve and server options with Packer defaults

### DIFF
--- a/.changeset/merge-resolve-and-server-defaults.md
+++ b/.changeset/merge-resolve-and-server-defaults.md
@@ -1,0 +1,7 @@
+---
+"@ekz/packer": patch
+---
+
+Deep-merge caller-supplied `resolve` and `server`/`devServer` options with Packer's defaults instead of overwriting them. Previously, passing any `resolve.alias` entry dropped the built-in `@root` alias, and passing any `server.headers`/`devServer.headers` entry dropped the default `Access-Control-Allow-Origin: *` header. This affected both the vite and webpack configurations.
+
+Note that defaults can no longer be removed by passing an empty object: `resolve.alias` and header entries are now always merged on top of Packer's defaults.

--- a/packages/packer/src/vite.ts
+++ b/packages/packer/src/vite.ts
@@ -56,25 +56,22 @@ function createApplicationConfiguration(opts: VitePackerOptions = {}): UserConfi
                 checker({ typescript: { tsconfigPath: typescriptConfigPath } }),
             ...asArray(plugins)
         ]),
-        resolve: Object.assign(
+        resolve: mergeConfig(
             {
-                alias: Object.assign(
-                    {
-                        '@root': path.resolve(appRoot, 'src')
-                    },
-                    resolve?.alias
-                )
+                alias: {
+                    '@root': path.resolve(appRoot, 'src')
+                }
             },
-            resolve
+            resolve ?? {}
         ),
-        server: Object.assign(
+        server: mergeConfig(
             {
                 headers: {
                     'Access-Control-Allow-Origin': '*'
                 },
                 port: 9000
             },
-            server
+            server ?? {}
         ),
         build: mergeConfig(
             {

--- a/packages/packer/src/webpack.ts
+++ b/packages/packer/src/webpack.ts
@@ -8,6 +8,8 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
+import type { Configuration } from 'webpack';
+
 import type {
     AssetPaths,
     PackerOptions,
@@ -104,18 +106,12 @@ function createApplicationConfiguration(opts: PackerOptions = {}): WebpackConfig
                     )
                 ].concat(options.plugins as [])
             ),
-            resolve: Object.assign(
-                {
-                    alias: Object.assign(
-                        {
-                            '@root': path.resolve(process.env.INIT_CWD!, 'src')
-                        },
-                        options.resolve?.alias
-                    ),
-                    extensions: options.fileExtensions
-                },
-                options.resolve
-            ),
+            resolve: Object.assign({ extensions: options.fileExtensions }, options.resolve, {
+                alias: mergeAlias(
+                    { '@root': path.resolve(process.env.INIT_CWD!, 'src') },
+                    options.resolve?.alias
+                )
+            }),
             externals: options.externals,
             module: {
                 rules: truthyArray(
@@ -166,14 +162,17 @@ function createApplicationConfiguration(opts: PackerOptions = {}): WebpackConfig
             },
             devServer: Object.assign(
                 {
-                    headers: {
-                        'Access-Control-Allow-Origin': '*'
-                    },
                     port: 9000,
                     compress: true,
                     hot: true
                 },
-                options.devServer
+                options.devServer,
+                {
+                    headers: mergeHeaders(
+                        { 'Access-Control-Allow-Origin': '*' },
+                        options.devServer?.headers
+                    )
+                }
             )
         };
     };
@@ -303,6 +302,45 @@ function hasModule(modulePath: string): boolean {
 
 function truthyArray<T>(array: (T | false | null | undefined)[]): T[] {
     return array.filter((item): item is T => item != null && item !== false);
+}
+
+type ResolveAlias = NonNullable<Configuration['resolve']>['alias'];
+
+function mergeAlias(defaults: Record<string, string>, alias: ResolveAlias): ResolveAlias {
+    if (alias == null) {
+        return defaults;
+    }
+
+    if (Array.isArray(alias)) {
+        return alias.concat(
+            Object.entries(defaults).map(([name, aliasPath]) => ({ name, alias: aliasPath }))
+        );
+    }
+
+    return Object.assign({}, defaults, alias);
+}
+
+type DevServerHeader = { key: string; value: string };
+
+function mergeHeaders(defaults: Record<string, string>, headers: unknown): unknown {
+    if (headers == null) {
+        return defaults;
+    }
+
+    if (Array.isArray(headers)) {
+        const overridden = new Set((headers as DevServerHeader[]).map((header) => header.key));
+
+        return Object.entries(defaults)
+            .filter(([key]) => !overridden.has(key))
+            .map(([key, value]): DevServerHeader => ({ key, value }))
+            .concat(headers as DevServerHeader[]);
+    }
+
+    if (typeof headers === 'function') {
+        return headers;
+    }
+
+    return Object.assign({}, defaults, headers);
 }
 
 function makePathResolvers(config: AssetPaths) {


### PR DESCRIPTION
Fixes #155.

`createApplicationConfiguration` merged the caller's `resolve`/`server` config with the built-in defaults using `Object.assign(defaults, callerObject)`. Since the caller's whole object is the last argument, its nested `alias`/`headers` key replaced the object computed one line above — so passing any `resolve.alias` entry silently dropped the built-in `@root` alias, and passing any header dropped the default `Access-Control-Allow-Origin: *`.

- **vite**: use vite's own `mergeConfig` for `resolve` and `server`, as `build` already does.
- **webpack**: the same bug is present for `resolve.alias` and `devServer.headers`, and `docs/content/guides/webpack-configuration.md` documents `devServer` as merged with the defaults. Webpack has no `mergeConfig`, so two small helpers merge the defaults, handling both the object and array forms of `alias` and `headers`.

Verified against the built package: with `resolve.alias` set, the vite dev server resolves `@root/App` to `/src/App.tsx` and responds with `Access-Control-Allow-Origin: *`; the webpack config keeps `@root` and the CORS header in both object and array forms. Output with no options passed is unchanged for both bundlers.

Behavior change: defaults can no longer be removed by passing an empty object — `server: { headers: {} }` now keeps the default CORS header instead of dropping it. Noted in the changeset.