### PR TITLE
Upload release provenance under Scorecard-recognized asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,16 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         run: |
-          version=$(node -p "require('./packages/packer/package.json').version")
-          gh release upload "@ekz/packer@$version" "${{ steps.attest.outputs.bundle-path }}" --clobber
-          gh release upload "@ekz/eslint-config-packer@$version" "${{ steps.attest.outputs.bundle-path }}" --clobber
+          # OpenSSF Scorecard matches release assets on filename suffix alone:
+          # .sigstore.json scores as signed, .intoto.jsonl as provenance.
+          cp "$BUNDLE_PATH" /tmp/provenance/provenance.sigstore.json
+          jq -ce '.dsseEnvelope' "$BUNDLE_PATH" > /tmp/provenance/provenance.intoto.jsonl
+
+          for pkg in packer eslint-config-packer; do
+            version=$(node -p "require('./packages/$pkg/package.json').version")
+            gh release upload "@ekz/$pkg@$version" \
+              /tmp/provenance/provenance.sigstore.json \
+              /tmp/provenance/provenance.intoto.jsonl --clobber
+          done


### PR DESCRIPTION
OpenSSF Scorecard's `Signed-Releases` check scored 0, reporting that releases were neither signed nor carrying provenance. The signing itself was fine — the asset filename was the problem.

The check matches GitHub Release assets by **filename suffix only**; it never opens the file, and it never looks at npm (so `npm publish --provenance` earns nothing here). It accepts `.asc`, `.minisig`, `.sig`, `.sign`, `.sigstore`, `.sigstore.json` as signed (8 pts) and `.intoto.jsonl` as provenance (10 pts). We were uploading the attestation as `attestation.json`, which matches neither.

## Changes

- Upload the bundle as `provenance.sigstore.json` (it genuinely is a Sigstore bundle) and the extracted DSSE envelope as `provenance.intoto.jsonl` (a real intoto jsonl, not a renamed bundle). `jq -e` fails the job rather than silently writing `null` if the bundle shape ever changes.
- Resolve each package's release tag from its **own** `package.json` version. The previous code used packer's version for both tags — fine while they move in lockstep, but it would target a nonexistent tag and fail the release job as soon as changesets bumps them independently.
- Move `bundle-path` into `env:` rather than interpolating `${{ }}` directly into the `run:` block.

## Existing releases

The four releases already carrying an `attestation.json` (1.0.1 and 1.0.2, both packages) have been backfilled with correctly-named copies derived from **each release's own bundle** — the tarball digests differ per version, so a shared copy would have attested artifacts the release never contained. Verified after upload: 1.0.1 attests `packer.tgz` at `sha256:5343453e…`, 1.0.2 at `sha256:da7f9959…`.

Those four are the only releases in the lookback window that count (assetless releases are skipped, not zeroed), so `Signed-Releases` should read 10 on the next scan.