### PR TITLE
Publish a real security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,12 @@
 
 Please **do not** open a public GitHub issue for security reports.
 
-Email security concerns to the maintainers of `@ekz/packer` (see npm maintainer contacts or your internal security channel). Include:
+Report privately through either channel:
+
+- [GitHub private vulnerability reporting](https://github.com/erkez/packer/security/advisories/new) — preferred, and keeps the report attached to the repository.
+- Email **security@ekz.io**.
+
+Include:
 
 - Package and version affected
 - Steps to reproduce


### PR DESCRIPTION
`SECURITY.md` instructed reporters to "email security concerns to the maintainers of `@ekz/packer` (see npm maintainer contacts or your internal security channel)" — which named no address. GitHub private vulnerability reporting was also disabled. Between the two, there was **no working channel to report a vulnerability privately**.

## Changes

- Private vulnerability reporting is now **enabled** on the repository (a settings change, already applied — not part of this diff).
- `SECURITY.md` now points at two real channels: the [GitHub private advisory form](https://github.com/erkez/packer/security/advisories/new), preferred, and **security@ekz.io** as a fallback.

Found while auditing the OpenSSF Baseline answers for [project 13614](https://www.bestpractices.dev/projects/13614); this closes `OSPS-VM-02.01` ("project documentation MUST contain security contacts") legitimately rather than by assertion.

Note this does not affect the Scorecard number — Scorecard reads the classic badge level, not the Baseline assessment. It's a real gap, fixed on its merits.