### PR TITLE
Add a test suite for the emitted configurations

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@ekz/packer': patch
+---
+
+Honour falsy `output` values instead of replacing them with the defaults. Each `output` field was defaulted with `||`, which could not tell "not supplied" from "supplied as a falsy value", so `output.publicPath: ''` — webpack's way of asking for relative asset URLs — was silently rewritten to `'/'`. `output` is now merged with its defaults once, like `assetPaths` already was.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
 
       - run: yarn build
 
+      - run: yarn test
+
       - run: yarn lint
 
       - run: yarn docs:build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,28 @@ Common tasks:
 | Command | Purpose |
 | --- | --- |
 | `yarn build` | Build `@ekz/packer` |
+| `yarn test` | Rebuild, then run the test suite |
 | `yarn lint` | Lint the package and the example apps |
 | `yarn audit` | Fail on high-severity advisories in the dependency tree |
 | `yarn docs:dev` | Run the documentation site locally |
 
 The `examples/` workspaces consume the local build, so `yarn workspace my-app build:prod` is a useful end-to-end check that a config change actually produces a working bundle.
+
+## Tests
+
+`packages/packer/test/` covers the emitted Webpack and Vite configurations, using Node's built-in test runner — there is no test framework to install.
+
+**Any change to how a configuration is generated needs a test.** New options, changed defaults, and changed merge behaviour are all user-visible, and an assertion on the emitted config is the cheapest way to keep them that way. Bug fixes should come with a test that fails without the fix.
+
+Tests run against the built `dist/`, which is what users consume, so `yarn test` rebuilds first — never run `node --test` directly, or you will be testing the previous build.
+
+Some behaviour is only observable inside a plugin instance rather than on the config object (the `eslint`, `define`, `provide` and `html` options, for example). Assert on the specific fields Packer sets — `findPlugin(config, 'DefinePlugin').definitions` — rather than snapshotting a whole plugin's options, which would churn whenever that plugin's own defaults change.
+
+Snapshots cover overall config shape. Regenerate them deliberately, and read the diff:
+
+```sh
+yarn workspace @ekz/packer test --test-update-snapshots
+```
 
 ## Submitting changes
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "yarn workspace @ekz/packer build",
+    "test": "yarn workspace @ekz/packer test",
     "lint": "yarn workspace @ekz/packer lint && yarn workspace my-app lint && yarn workspace my-vite-app lint",
     "docs:dev": "yarn workspace packer-docs start",
     "docs:build": "yarn workspace packer-docs build",

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build",
+    "test": "yarn build && node --test 'test/**/*.test.js'",
     "lint": "npx eslint .",
     "lint:fix": "yarn lint --fix"
   },

--- a/packages/packer/src/webpack.ts
+++ b/packages/packer/src/webpack.ts
@@ -18,14 +18,17 @@ import type {
 } from './types';
 
 function createApplicationConfiguration(opts: PackerOptions = {}): WebpackConfigFactory {
-    const options = Object.assign({}, DefaultOptions, opts) as ResolvedPackerOptions;
+    // Unlike the options handed to a plugin wholesale, assetPaths and output are read field by
+    // field, so their defaults must be merged in here or a caller's partial object drops the rest.
+    const options = Object.assign({}, DefaultOptions, opts, {
+        assetPaths: Object.assign({}, DefaultOptions.assetPaths, opts.assetPaths),
+        output: Object.assign({}, DefaultOptions.output, opts.output)
+    }) as ResolvedPackerOptions;
 
     return function configure(_env, argv) {
         const isProduction = argv.mode === 'production';
 
-        const pathResolvers = makePathResolvers(
-            Object.assign({}, DefaultOptions.assetPaths, options.assetPaths)
-        );
+        const pathResolvers = makePathResolvers(options.assetPaths);
 
         const typescriptConfigPath = resolveTypeScriptConfigPath(
             options.tsconfigPath,
@@ -44,18 +47,15 @@ function createApplicationConfiguration(opts: PackerOptions = {}): WebpackConfig
             target: options.target,
             node: options.node,
             output: {
-                path: path.resolve(
-                    process.env.INIT_CWD!,
-                    options.output.path || DefaultOptions.output.path
-                ),
+                path: path.resolve(process.env.INIT_CWD!, options.output.path),
                 assetModuleFilename: pathResolvers.staticAsset(
                     isProduction && options.useHashInFileNames
                         ? '[name].[hash:8][ext][query]'
                         : '[name][ext][query]'
                 ),
-                library: options.output.library || DefaultOptions.output.library,
-                libraryTarget: options.output.libraryTarget || DefaultOptions.output.libraryTarget,
-                publicPath: options.output.publicPath || DefaultOptions.output.publicPath,
+                library: options.output.library,
+                libraryTarget: options.output.libraryTarget,
+                publicPath: options.output.publicPath,
                 globalObject: options.output.globalObject,
                 filename: pathResolvers.jsAsset(
                     isProduction && options.useHashInFileNames

--- a/packages/packer/test/fixtures/custom-ts/custom.tsconfig.json
+++ b/packages/packer/test/fixtures/custom-ts/custom.tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strict": true
+    }
+}

--- a/packages/packer/test/fixtures/js-app/.gitkeep
+++ b/packages/packer/test/fixtures/js-app/.gitkeep
@@ -1,0 +1,1 @@
+This fixture deliberately has no tsconfig.json, exercising the JavaScript-only branch.

--- a/packages/packer/test/fixtures/ts-app/tsconfig.json
+++ b/packages/packer/test/fixtures/ts-app/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "jsx": "react-jsx"
+    }
+}

--- a/packages/packer/test/helpers.js
+++ b/packages/packer/test/helpers.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const path = require('path');
+
+const packer = require('../dist/index.js');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function fixture(name) {
+    return path.join(FIXTURES, name);
+}
+
+/**
+ * Both factories resolve paths against INIT_CWD, which yarn sets but `node --test` does not.
+ * Webpack throws without it; vite silently falls back to process.cwd() and picks up packer's own
+ * tsconfig.json, so every test must pin it explicitly rather than rely on a default.
+ */
+function withInitCwd(name, run) {
+    const previous = process.env.INIT_CWD;
+    process.env.INIT_CWD = fixture(name);
+
+    try {
+        return run();
+    } finally {
+        if (previous === undefined) {
+            delete process.env.INIT_CWD;
+        } else {
+            process.env.INIT_CWD = previous;
+        }
+    }
+}
+
+function webpackConfig(opts = {}, { mode = 'production', app = 'ts-app' } = {}) {
+    return withInitCwd(app, () =>
+        packer.webpack.createApplicationConfiguration(opts)(null, { mode })
+    );
+}
+
+function libraryConfig(name, opts = {}, { mode = 'production', app = 'ts-app' } = {}) {
+    return withInitCwd(app, () =>
+        packer.webpack.createLibraryConfiguration(name, opts)(null, { mode })
+    );
+}
+
+function viteConfig(opts = {}, { app = 'ts-app' } = {}) {
+    return withInitCwd(app, () => packer.vite.createApplicationConfiguration(opts));
+}
+
+function pluginNames(config) {
+    return config.plugins.map((plugin) => plugin.constructor.name);
+}
+
+function findPlugin(config, name) {
+    return config.plugins.find((plugin) => plugin.constructor.name === name);
+}
+
+function vitePluginNames(config) {
+    return config.plugins
+        .flat(Infinity)
+        .filter(Boolean)
+        .map((plugin) => plugin.name);
+}
+
+function babelOptions(config) {
+    return config.module.rules.find((rule) => rule.use && rule.use.loader === 'babel-loader').use
+        .options;
+}
+
+/**
+ * Snapshots of the raw config are not portable: it embeds absolute INIT_CWD and node_modules paths,
+ * live plugin instances, functions and regexes. Project it onto something stable — absolute paths
+ * become tokens, plugins become their constructor name — so a snapshot pins Packer's own output
+ * rather than the internals of whichever plugin version happens to be installed.
+ */
+function normalize(value, app) {
+    const root = fixture(app);
+
+    function walk(node) {
+        if (node == null || typeof node === 'boolean' || typeof node === 'number') {
+            return node;
+        }
+
+        if (typeof node === 'string') {
+            return node.split(root).join('<root>').split(REPO_ROOT).join('<repo>');
+        }
+
+        if (typeof node === 'function') {
+            return '[Function]';
+        }
+
+        if (node instanceof RegExp) {
+            return String(node);
+        }
+
+        if (Array.isArray(node)) {
+            return node.map(walk);
+        }
+
+        if (node.constructor && node.constructor !== Object) {
+            return `[${node.constructor.name}]`;
+        }
+
+        return Object.fromEntries(
+            Object.entries(node)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([key, item]) => [key, walk(item)])
+        );
+    }
+
+    return walk(value);
+}
+
+module.exports = {
+    babelOptions,
+    findPlugin,
+    fixture,
+    libraryConfig,
+    normalize,
+    pluginNames,
+    viteConfig,
+    vitePluginNames,
+    webpackConfig,
+    withInitCwd
+};

--- a/packages/packer/test/vite.test.js
+++ b/packages/packer/test/vite.test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { normalize, viteConfig, vitePluginNames } = require('./helpers');
+
+function assetFileNames(config) {
+    return config.build.rollupOptions.output.assetFileNames;
+}
+
+test('root resolves against INIT_CWD, and @root aliases its src directory', () => {
+    const config = viteConfig();
+
+    assert.ok(config.root.endsWith('/ts-app'));
+    assert.ok(config.resolve.alias['@root'].endsWith('/ts-app/src'));
+});
+
+test('root option is resolved relative to INIT_CWD', () => {
+    const config = viteConfig({ root: 'app' });
+
+    assert.ok(config.root.endsWith('/ts-app/app'));
+    assert.ok(config.resolve.alias['@root'].endsWith('/ts-app/app/src'));
+});
+
+test('default plugins are react and the type checker', () => {
+    const names = vitePluginNames(viteConfig());
+
+    assert.ok(
+        names.some((name) => name.startsWith('vite:react')),
+        'react plugin is present'
+    );
+    assert.ok(names.includes('vite-plugin-checker'));
+});
+
+test('react: false drops the react plugin', () => {
+    const names = vitePluginNames(viteConfig({ react: false }));
+
+    assert.ok(!names.some((name) => name.startsWith('vite:react')));
+    assert.ok(names.includes('vite-plugin-checker'), 'the checker is unaffected');
+});
+
+test('typecheck: false drops the checker plugin', () => {
+    const names = vitePluginNames(viteConfig({ typecheck: false }));
+
+    assert.ok(!names.includes('vite-plugin-checker'));
+    assert.ok(
+        names.some((name) => name.startsWith('vite:react')),
+        'react is unaffected'
+    );
+});
+
+test('an app with no tsconfig.json gets no checker, without throwing', () => {
+    const names = vitePluginNames(viteConfig({}, { app: 'js-app' }));
+
+    assert.ok(!names.includes('vite-plugin-checker'));
+});
+
+test('custom plugins are appended to the defaults', () => {
+    const plugin = { name: 'my-plugin' };
+    const names = vitePluginNames(viteConfig({ plugins: [plugin] }));
+
+    assert.equal(names.at(-1), 'my-plugin');
+    assert.ok(names.includes('vite-plugin-checker'), 'defaults are kept');
+});
+
+test('server defaults, and user options merge over them', () => {
+    const defaults = viteConfig().server;
+
+    assert.equal(defaults.port, 9000);
+    assert.deepEqual(defaults.headers, { 'Access-Control-Allow-Origin': '*' });
+
+    const custom = viteConfig({ server: { port: 3000 } }).server;
+    assert.equal(custom.port, 3000);
+    assert.deepEqual(
+        custom.headers,
+        { 'Access-Control-Allow-Origin': '*' },
+        'the CORS default survives'
+    );
+});
+
+test('resolve options merge with the @root alias', () => {
+    const config = viteConfig({ resolve: { alias: { '@ui': '/ui' } } });
+
+    assert.equal(config.resolve.alias['@ui'], '/ui');
+    assert.ok(config.resolve.alias['@root'].endsWith('/ts-app/src'));
+});
+
+test('outDir defaults to dist and is overridable', () => {
+    assert.equal(viteConfig().build.outDir, 'dist');
+    assert.equal(viteConfig({ outDir: 'build' }).build.outDir, 'build');
+});
+
+test('a string entry resolves to an absolute path', () => {
+    const input = viteConfig().build.rollupOptions.input;
+    assert.ok(input.endsWith('/ts-app/index.html'));
+
+    const custom = viteConfig({ entry: 'src/main.tsx' }).build.rollupOptions.input;
+    assert.ok(custom.endsWith('/ts-app/src/main.tsx'));
+});
+
+test('a record entry resolves each path, preserving the keys', () => {
+    const input = viteConfig({
+        entry: { app: 'src/app.tsx', admin: 'src/admin.tsx' }
+    }).build.rollupOptions.input;
+
+    assert.deepEqual(Object.keys(input), ['app', 'admin']);
+    assert.ok(input.app.endsWith('/ts-app/src/app.tsx'));
+    assert.ok(input.admin.endsWith('/ts-app/src/admin.tsx'));
+});
+
+test('build options merge over the derived rollup config', () => {
+    const config = viteConfig({ build: { sourcemap: true } });
+
+    assert.equal(config.build.sourcemap, true);
+    assert.equal(config.build.outDir, 'dist', 'derived options survive');
+    assert.ok(config.build.rollupOptions.input, 'the entry survives');
+});
+
+test('js chunk and entry filenames are hashed by default', () => {
+    const { output } = viteConfig().build.rollupOptions;
+
+    assert.equal(output.entryFileNames, 'assets/js/[name]-[hash].js');
+    assert.equal(output.chunkFileNames, 'assets/js/[name]-[hash].js');
+});
+
+test('useHashInFileNames: false removes the hash', () => {
+    const { output } = viteConfig({ useHashInFileNames: false }).build.rollupOptions;
+
+    assert.equal(output.entryFileNames, 'assets/js/[name].js');
+    assert.equal(output.chunkFileNames, 'assets/js/[name].js');
+});
+
+test('assetFileNames routes css and other assets to their own paths', () => {
+    const names = assetFileNames(viteConfig());
+
+    assert.equal(
+        names({ names: ['style.css'], originalFileNames: [] }),
+        'assets/css/[name]-[hash][extname]'
+    );
+    assert.equal(
+        names({ names: ['logo.png'], originalFileNames: [] }),
+        'assets/static/[name]-[hash][extname]'
+    );
+});
+
+test('assetFileNames falls back to originalFileNames, then to the static path', () => {
+    const names = assetFileNames(viteConfig());
+
+    assert.equal(
+        names({ names: [], originalFileNames: ['style.css'] }),
+        'assets/css/[name]-[hash][extname]'
+    );
+    assert.equal(
+        names({ names: [], originalFileNames: [] }),
+        'assets/static/[name]-[hash][extname]'
+    );
+});
+
+test('assetFileNames honours assetPaths and useHashInFileNames', () => {
+    const names = assetFileNames(
+        viteConfig({
+            assetPaths: { css: 'styles/' },
+            useHashInFileNames: false
+        })
+    );
+
+    assert.equal(names({ names: ['style.css'], originalFileNames: [] }), 'styles/[name][extname]');
+    assert.equal(
+        names({ names: ['logo.png'], originalFileNames: [] }),
+        'assets/static/[name][extname]',
+        'static keeps its default'
+    );
+});
+
+test('an explicit tsconfigPath is honoured', () => {
+    const names = vitePluginNames(
+        viteConfig({ tsconfigPath: 'custom.tsconfig.json' }, { app: 'custom-ts' })
+    );
+
+    assert.ok(names.includes('vite-plugin-checker'));
+});
+
+test('an explicit but missing tsconfigPath throws', () => {
+    assert.throws(() => viteConfig({ tsconfigPath: 'nope.json' }), {
+        message: /TypeScript config not found:.*nope\.json/
+    });
+});
+
+test('unknown vite options are merged into the config', () => {
+    const config = viteConfig({ base: '/app/', envPrefix: 'APP_' });
+
+    assert.equal(config.base, '/app/');
+    assert.equal(config.envPrefix, 'APP_');
+});
+
+test('snapshot: default config', (t) => {
+    t.assert.snapshot(normalize(viteConfig(), 'ts-app'));
+});
+
+test('snapshot: config without react or typechecking', (t) => {
+    t.assert.snapshot(normalize(viteConfig({ react: false, typecheck: false }), 'ts-app'));
+});

--- a/packages/packer/test/vite.test.js.snapshot
+++ b/packages/packer/test/vite.test.js.snapshot
@@ -1,0 +1,132 @@
+exports[`snapshot: config without react or typechecking 1`] = `
+{
+  "build": {
+    "outDir": "dist",
+    "rollupOptions": {
+      "input": "<root>/index.html",
+      "output": {
+        "assetFileNames": "[Function]",
+        "chunkFileNames": "assets/js/[name]-[hash].js",
+        "entryFileNames": "assets/js/[name]-[hash].js"
+      }
+    }
+  },
+  "plugins": [],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    }
+  },
+  "root": "<root>",
+  "server": {
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "port": 9000
+  }
+}
+`;
+
+exports[`snapshot: default config 1`] = `
+{
+  "build": {
+    "outDir": "dist",
+    "rollupOptions": {
+      "input": "<root>/index.html",
+      "output": {
+        "assetFileNames": "[Function]",
+        "chunkFileNames": "assets/js/[name]-[hash].js",
+        "entryFileNames": "assets/js/[name]-[hash].js"
+      }
+    }
+  },
+  "plugins": [
+    [
+      {
+        "config": "[Function]",
+        "configResolved": "[Function]",
+        "enforce": "pre",
+        "name": "vite:react-babel",
+        "options": "[Function]"
+      },
+      {
+        "apply": "serve",
+        "applyToEnvironment": "[Function]",
+        "name": "vite:react:refresh-wrapper"
+      },
+      {
+        "config": "[Function]",
+        "enforce": "post",
+        "name": "vite:react:config-post"
+      },
+      {
+        "enforce": "pre",
+        "name": "vite:react-refresh-fbm",
+        "transformIndexHtml": {
+          "handler": "[Function]",
+          "order": "pre"
+        }
+      },
+      {
+        "config": "[Function]",
+        "enforce": "pre",
+        "load": {
+          "filter": {
+            "id": "/^\\\\/@react\\\\-refresh$/"
+          },
+          "handler": "[Function]"
+        },
+        "name": "vite:react-refresh",
+        "resolveId": {
+          "filter": {
+            "id": "/^\\\\/@react\\\\-refresh$/"
+          },
+          "handler": "[Function]"
+        },
+        "transformIndexHtml": "[Function]"
+      },
+      {
+        "load": {
+          "filter": {
+            "id": "/^\\u0000@vitejs\\\\/plugin\\\\-react\\\\/preamble$/"
+          },
+          "handler": "[Function]"
+        },
+        "name": "vite:react-virtual-preamble",
+        "resolveId": {
+          "filter": {
+            "id": "/^@vitejs\\\\/plugin\\\\-react\\\\/preamble$/"
+          },
+          "handler": "[Function]",
+          "order": "pre"
+        }
+      }
+    ],
+    {
+      "__internal__checker": "[Function]",
+      "buildEnd": "[Function]",
+      "buildStart": "[Function]",
+      "config": "[Function]",
+      "configResolved": "[Function]",
+      "configureServer": "[Function]",
+      "enforce": "pre",
+      "load": "[Function]",
+      "name": "vite-plugin-checker",
+      "resolveId": "[Function]",
+      "transformIndexHtml": "[Function]"
+    }
+  ],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    }
+  },
+  "root": "<root>",
+  "server": {
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "port": 9000
+  }
+}
+`;

--- a/packages/packer/test/webpack.test.js
+++ b/packages/packer/test/webpack.test.js
@@ -131,6 +131,18 @@ test('output defaults resolve against INIT_CWD', () => {
     assert.ok(config.cache.cacheDirectory.endsWith('/ts-app/node_modules/.cache/webpack'));
 });
 
+test('a partial output merges with the defaults', () => {
+    const config = webpackConfig({ output: { path: 'build' } });
+
+    assert.ok(config.output.path.endsWith('/ts-app/build'));
+    assert.equal(config.output.publicPath, '/', 'the fields not supplied keep their defaults');
+});
+
+test('an empty publicPath is honoured rather than replaced by the default', () => {
+    // webpack reads '' as "emit relative asset URLs", so it must survive as an explicit choice.
+    assert.equal(webpackConfig({ output: { publicPath: '' } }).output.publicPath, '');
+});
+
 test('entry, target, node and splitChunks pass through', () => {
     assert.deepEqual(webpackConfig().entry, { main: './src/index.js' });
     assert.deepEqual(webpackConfig({ entry: { app: './src/app.js' } }).entry, {

--- a/packages/packer/test/webpack.test.js
+++ b/packages/packer/test/webpack.test.js
@@ -1,0 +1,415 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const {
+    babelOptions,
+    findPlugin,
+    libraryConfig,
+    normalize,
+    pluginNames,
+    webpackConfig
+} = require('./helpers');
+
+test('mode is passed through and drives production', () => {
+    assert.equal(webpackConfig().mode, 'production');
+    assert.equal(webpackConfig({}, { mode: 'development' }).mode, 'development');
+});
+
+test('production hashes js, css and static asset filenames', () => {
+    const config = webpackConfig();
+
+    assert.equal(config.output.filename, 'assets/js/[name].[chunkhash:8].js');
+    assert.equal(config.output.chunkFilename, 'assets/js/[id].[chunkhash:8].js');
+    assert.equal(config.output.assetModuleFilename, 'assets/static/[name].[hash:8][ext][query]');
+    assert.equal(
+        findPlugin(config, 'MiniCssExtractPlugin').options.filename,
+        'assets/css/[name].[chunkhash:8].css'
+    );
+});
+
+test('development does not hash filenames', () => {
+    const config = webpackConfig({}, { mode: 'development' });
+
+    assert.equal(config.output.filename, 'assets/js/[name].js');
+    assert.equal(config.output.chunkFilename, 'assets/js/[id].js');
+    assert.equal(config.output.assetModuleFilename, 'assets/static/[name][ext][query]');
+    assert.equal(
+        findPlugin(config, 'MiniCssExtractPlugin').options.filename,
+        'assets/css/[name].css'
+    );
+});
+
+test('useHashInFileNames: false disables hashing even in production', () => {
+    const config = webpackConfig({ useHashInFileNames: false });
+
+    assert.equal(config.output.filename, 'assets/js/[name].js');
+    assert.equal(config.output.chunkFilename, 'assets/js/[id].js');
+});
+
+test('devtool is applied in development and dropped in production', () => {
+    assert.equal(webpackConfig().devtool, undefined);
+    assert.equal(
+        webpackConfig({}, { mode: 'development' }).devtool,
+        'eval-cheap-module-source-map'
+    );
+    assert.equal(
+        webpackConfig({ devtool: 'source-map' }, { mode: 'development' }).devtool,
+        'source-map'
+    );
+});
+
+test('minification is production-only, and terserOptions reach Terser', () => {
+    assert.equal(webpackConfig().optimization.minimize, true);
+    assert.equal(webpackConfig({}, { mode: 'development' }).optimization.minimize, false);
+
+    const config = webpackConfig({ terserOptions: { parallel: false } });
+    assert.equal(config.optimization.minimizer[0].options.parallel, false);
+});
+
+test('eslint plugin fails the build only in production', () => {
+    const production = findPlugin(webpackConfig(), 'ESLintWebpackPlugin').options;
+    assert.equal(production.failOnError, true);
+    assert.equal(production.failOnWarning, true);
+    assert.equal(production.emitWarning, false);
+    assert.equal(production.lintDirtyModulesOnly, false);
+
+    const development = findPlugin(
+        webpackConfig({}, { mode: 'development' }),
+        'ESLintWebpackPlugin'
+    ).options;
+    assert.equal(development.failOnError, false);
+    assert.equal(development.emitWarning, true);
+    assert.equal(development.lintDirtyModulesOnly, true);
+});
+
+test('eslint option overrides the mode-derived defaults', () => {
+    const config = webpackConfig({ eslint: { failOnWarning: false } });
+    const { options } = findPlugin(config, 'ESLintWebpackPlugin');
+
+    assert.equal(options.failOnWarning, false);
+    assert.equal(options.failOnError, true, 'unrelated defaults survive the merge');
+});
+
+test('assetPaths default, and partial overrides merge with the defaults', () => {
+    const config = webpackConfig({ assetPaths: { js: 'static/js/' } });
+
+    assert.equal(config.output.filename, 'static/js/[name].[chunkhash:8].js');
+    assert.equal(
+        findPlugin(config, 'MiniCssExtractPlugin').options.filename,
+        'assets/css/[name].[chunkhash:8].css',
+        'css keeps its default when only js is overridden'
+    );
+});
+
+test('output path, publicPath, library, libraryTarget and globalObject', () => {
+    const config = webpackConfig({
+        output: {
+            path: 'build',
+            publicPath: '/static/',
+            library: 'Thing',
+            libraryTarget: 'umd',
+            globalObject: 'this'
+        }
+    });
+
+    assert.ok(config.output.path.endsWith('/build'));
+    assert.ok(path.isAbsolute(config.output.path));
+    assert.equal(config.output.publicPath, '/static/');
+    assert.equal(config.output.library, 'Thing');
+    assert.equal(config.output.libraryTarget, 'umd');
+    assert.equal(config.output.globalObject, 'this');
+});
+
+test('output defaults resolve against INIT_CWD', () => {
+    const config = webpackConfig();
+
+    assert.ok(config.output.path.endsWith('/ts-app/dist'));
+    assert.equal(config.output.publicPath, '/');
+    assert.ok(config.cache.cacheDirectory.endsWith('/ts-app/node_modules/.cache/webpack'));
+});
+
+test('entry, target, node and splitChunks pass through', () => {
+    assert.deepEqual(webpackConfig().entry, { main: './src/index.js' });
+    assert.deepEqual(webpackConfig({ entry: { app: './src/app.js' } }).entry, {
+        app: './src/app.js'
+    });
+
+    assert.equal(webpackConfig().target, 'web');
+    assert.equal(webpackConfig({ target: 'node' }).target, 'node');
+
+    assert.equal(webpackConfig().node, undefined);
+    assert.deepEqual(webpackConfig({ node: { __dirname: false } }).node, { __dirname: false });
+
+    assert.deepEqual(webpackConfig().optimization.splitChunks, {
+        chunks: 'all',
+        automaticNameDelimiter: '.'
+    });
+    assert.deepEqual(webpackConfig({ splitChunks: { chunks: 'async' } }).optimization.splitChunks, {
+        chunks: 'async'
+    });
+});
+
+test('externals and fileExtensions pass through', () => {
+    assert.deepEqual(webpackConfig({ externals: { react: 'React' } }).externals, {
+        react: 'React'
+    });
+    assert.deepEqual(webpackConfig().resolve.extensions, ['.js', '.jsx', '.ts', '.tsx']);
+    assert.deepEqual(webpackConfig({ fileExtensions: ['.js'] }).resolve.extensions, ['.js']);
+});
+
+test('provide and define reach their plugins', () => {
+    const config = webpackConfig({
+        provide: { React: 'react' },
+        define: { __DEV__: false }
+    });
+
+    assert.deepEqual(findPlugin(config, 'ProvidePlugin').definitions, { React: 'react' });
+    assert.deepEqual(findPlugin(config, 'DefinePlugin').definitions, { __DEV__: false });
+});
+
+test('default plugin set', () => {
+    assert.deepEqual(pluginNames(webpackConfig()), [
+        'ESLintWebpackPlugin',
+        'ProgressPlugin',
+        'CleanWebpackPlugin',
+        'ForkTsCheckerWebpackPlugin',
+        'ProvidePlugin',
+        'DefinePlugin',
+        'HtmlWebpackPlugin',
+        'MiniCssExtractPlugin'
+    ]);
+});
+
+test('enableProgressPlugin: false drops the progress plugin', () => {
+    assert.ok(
+        !pluginNames(webpackConfig({ enableProgressPlugin: false })).includes('ProgressPlugin')
+    );
+});
+
+test('html: null drops HtmlWebpackPlugin, and html options reach it', () => {
+    assert.ok(!pluginNames(webpackConfig({ html: null })).includes('HtmlWebpackPlugin'));
+
+    const config = webpackConfig({ html: { title: 'Hello' } });
+    assert.equal(findPlugin(config, 'HtmlWebpackPlugin').options.title, 'Hello');
+});
+
+test('miniCssExtractPluginOptions merges over the derived filename', () => {
+    const config = webpackConfig({ miniCssExtractPluginOptions: { ignoreOrder: true } });
+    const { options } = findPlugin(config, 'MiniCssExtractPlugin');
+
+    assert.equal(options.ignoreOrder, true);
+    assert.equal(options.filename, 'assets/css/[name].[chunkhash:8].css');
+});
+
+test('custom plugins are appended to the defaults', () => {
+    class MyPlugin {
+        apply() {}
+    }
+
+    const names = pluginNames(webpackConfig({ plugins: [new MyPlugin()] }));
+
+    assert.equal(names.at(-1), 'MyPlugin');
+    assert.ok(names.includes('MiniCssExtractPlugin'), 'defaults are kept');
+});
+
+test('custom loaders are appended to the default rules', () => {
+    const loader = { test: /\.toml$/, loader: 'toml-loader' };
+    const rules = webpackConfig({ loaders: [loader] }).module.rules;
+
+    assert.deepEqual(rules.at(-1), loader);
+    assert.ok(rules.length > 1, 'default rules are kept');
+});
+
+test('resolve.alias merges @root with a user object alias', () => {
+    const config = webpackConfig({ resolve: { alias: { '@ui': './src/ui' } } });
+
+    assert.ok(config.resolve.alias['@root'].endsWith('/ts-app/src'));
+    assert.equal(config.resolve.alias['@ui'], './src/ui');
+});
+
+test('resolve.alias appends @root to a user array alias', () => {
+    const config = webpackConfig({
+        resolve: { alias: [{ name: '@ui', alias: './src/ui' }] }
+    });
+
+    assert.equal(config.resolve.alias[0].name, '@ui');
+    assert.equal(config.resolve.alias[1].name, '@root');
+    assert.ok(config.resolve.alias[1].alias.endsWith('/ts-app/src'));
+});
+
+test('a user alias may override @root itself', () => {
+    const config = webpackConfig({ resolve: { alias: { '@root': './elsewhere' } } });
+
+    assert.equal(config.resolve.alias['@root'], './elsewhere');
+});
+
+test('devServer defaults, and user options merge over them', () => {
+    const defaults = webpackConfig().devServer;
+
+    assert.equal(defaults.port, 9000);
+    assert.equal(defaults.compress, true);
+    assert.equal(defaults.hot, true);
+    assert.deepEqual(defaults.headers, { 'Access-Control-Allow-Origin': '*' });
+
+    const custom = webpackConfig({ devServer: { port: 3000 } }).devServer;
+    assert.equal(custom.port, 3000);
+    assert.equal(custom.compress, true, 'unrelated defaults survive');
+});
+
+test('devServer headers merge as an object, keeping the CORS default', () => {
+    const { headers } = webpackConfig({
+        devServer: { headers: { 'X-Custom': 'yes' } }
+    }).devServer;
+
+    assert.deepEqual(headers, {
+        'Access-Control-Allow-Origin': '*',
+        'X-Custom': 'yes'
+    });
+});
+
+test('devServer array headers replace a default of the same key', () => {
+    const { headers } = webpackConfig({
+        devServer: {
+            headers: [{ key: 'Access-Control-Allow-Origin', value: 'https://example.com' }]
+        }
+    }).devServer;
+
+    assert.deepEqual(headers, [
+        { key: 'Access-Control-Allow-Origin', value: 'https://example.com' }
+    ]);
+});
+
+test('devServer array headers keep defaults they do not override', () => {
+    const { headers } = webpackConfig({
+        devServer: { headers: [{ key: 'X-Custom', value: 'yes' }] }
+    }).devServer;
+
+    assert.deepEqual(headers, [
+        { key: 'Access-Control-Allow-Origin', value: '*' },
+        { key: 'X-Custom', value: 'yes' }
+    ]);
+});
+
+test('a devServer headers function is passed through untouched', () => {
+    const headers = () => ({ 'X-Custom': 'yes' });
+    const config = webpackConfig({ devServer: { headers } });
+
+    assert.equal(config.devServer.headers, headers);
+});
+
+test('babel presets and plugins, with the app-level additions appended', () => {
+    const options = babelOptions(webpackConfig());
+
+    assert.deepEqual(options.presets, [
+        ['@babel/env', { targets: '> 0.25%, not dead' }],
+        '@babel/react'
+    ]);
+    assert.deepEqual(options.plugins, [
+        '@babel/plugin-transform-class-properties',
+        '@babel/plugin-transform-object-rest-spread'
+    ]);
+    assert.deepEqual(options.only, ['src']);
+
+    const custom = babelOptions(
+        webpackConfig({
+            babelEnvTargets: 'last 2 versions',
+            babelPresets: ['@babel/flow'],
+            babelPlugins: ['babel-plugin-macros']
+        })
+    );
+
+    assert.deepEqual(custom.presets[0], ['@babel/env', { targets: 'last 2 versions' }]);
+    assert.equal(custom.presets.at(-1), '@babel/flow');
+    assert.equal(custom.plugins.at(-1), 'babel-plugin-macros');
+});
+
+test('babelOptions merges over the derived options', () => {
+    const options = babelOptions(webpackConfig({ babelOptions: { cacheDirectory: false } }));
+
+    assert.equal(options.cacheDirectory, false);
+    assert.deepEqual(options.only, ['src'], 'unrelated derived options survive');
+});
+
+test('a TypeScript app gets ts-loader, a type checker, and no @babel/typescript', () => {
+    const config = webpackConfig();
+
+    assert.ok(pluginNames(config).includes('ForkTsCheckerWebpackPlugin'));
+
+    const tsRule = config.module.rules.find((rule) => rule.loader === 'ts-loader');
+    assert.ok(tsRule, 'ts-loader rule is present');
+    assert.ok(tsRule.options.configFile.endsWith('/ts-app/tsconfig.json'));
+
+    assert.ok(!babelOptions(config).presets.includes('@babel/typescript'));
+    assert.deepEqual(babelOptions(config).presets.length, 2);
+});
+
+test('a JavaScript-only app gets no ts-loader, and babel handles TypeScript instead', () => {
+    const config = webpackConfig({}, { app: 'js-app' });
+
+    assert.ok(!pluginNames(config).includes('ForkTsCheckerWebpackPlugin'));
+    assert.ok(!config.module.rules.some((rule) => rule.loader === 'ts-loader'));
+
+    assert.ok(babelOptions(config).presets.includes('@babel/typescript'));
+
+    const babelRule = config.module.rules.find(
+        (rule) => rule.use && rule.use.loader === 'babel-loader'
+    );
+    assert.equal(String(babelRule.test), String(/\.(jsx?|tsx?)$/));
+});
+
+test('an explicit tsconfigPath is honoured', () => {
+    const config = webpackConfig({ tsconfigPath: 'custom.tsconfig.json' }, { app: 'custom-ts' });
+
+    const tsRule = config.module.rules.find((rule) => rule.loader === 'ts-loader');
+    assert.ok(tsRule.options.configFile.endsWith('/custom-ts/custom.tsconfig.json'));
+});
+
+test('an explicit but missing tsconfigPath throws', () => {
+    assert.throws(() => webpackConfig({ tsconfigPath: 'nope.json' }), {
+        message: /TypeScript config not found:.*nope\.json/
+    });
+});
+
+test('a missing default tsconfig.json does not throw', () => {
+    assert.doesNotThrow(() => webpackConfig({}, { app: 'js-app' }));
+});
+
+test('createLibraryConfiguration sets the library and its defaults', () => {
+    const config = libraryConfig('MyLib');
+
+    assert.equal(config.output.library, 'MyLib');
+    assert.equal(config.output.libraryTarget, 'umd');
+    assert.equal(config.output.filename, '[name].js', 'no hashing and no asset path prefix');
+    assert.deepEqual(config.optimization.splitChunks, {});
+    assert.ok(!pluginNames(config).includes('HtmlWebpackPlugin'), 'html defaults to null');
+});
+
+test('createLibraryConfiguration options override the library defaults', () => {
+    const config = libraryConfig('MyLib', {
+        useHashInFileNames: true,
+        output: { libraryTarget: 'commonjs2' }
+    });
+
+    assert.equal(config.output.libraryTarget, 'commonjs2');
+    assert.equal(config.output.library, 'MyLib', 'the library name is not overridable');
+    assert.equal(config.output.filename, '[name].[chunkhash:8].js');
+});
+
+test('snapshot: default production config', (t) => {
+    t.assert.snapshot(normalize(webpackConfig(), 'ts-app'));
+});
+
+test('snapshot: default development config', (t) => {
+    t.assert.snapshot(normalize(webpackConfig({}, { mode: 'development' }), 'ts-app'));
+});
+
+test('snapshot: JavaScript-only production config', (t) => {
+    t.assert.snapshot(normalize(webpackConfig({}, { app: 'js-app' }), 'js-app'));
+});
+
+test('snapshot: library config', (t) => {
+    t.assert.snapshot(normalize(libraryConfig('MyLib'), 'ts-app'));
+});

--- a/packages/packer/test/webpack.test.js.snapshot
+++ b/packages/packer/test/webpack.test.js.snapshot
@@ -1,0 +1,468 @@
+exports[`snapshot: JavaScript-only production config 1`] = `
+{
+  "cache": {
+    "cacheDirectory": "<root>/node_modules/.cache/webpack",
+    "type": "filesystem"
+  },
+  "devServer": {
+    "compress": true,
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "hot": true,
+    "port": 9000
+  },
+  "entry": {
+    "main": "./src/index.js"
+  },
+  "externals": {},
+  "mode": "production",
+  "module": {
+    "rules": [
+      {
+        "exclude": "/node_modules/",
+        "test": "/\\\\.(jsx?|tsx?)$/",
+        "use": {
+          "loader": "babel-loader",
+          "options": {
+            "cacheCompression": false,
+            "cacheDirectory": true,
+            "only": [
+              "src"
+            ],
+            "plugins": [
+              "@babel/plugin-transform-class-properties",
+              "@babel/plugin-transform-object-rest-spread"
+            ],
+            "presets": [
+              [
+                "@babel/env",
+                {
+                  "targets": "> 0.25%, not dead"
+                }
+              ],
+              "@babel/react",
+              "@babel/typescript"
+            ]
+          }
+        }
+      },
+      {
+        "loader": "node-loader",
+        "test": "/\\\\.node$/"
+      },
+      {
+        "test": "/\\\\.(css|s[ac]ss)$/i",
+        "use": [
+          {
+            "loader": "<repo>/node_modules/mini-css-extract-plugin/dist/loader.js"
+          },
+          "css-loader",
+          "sass-loader"
+        ]
+      },
+      {
+        "test": "/\\\\.(woff|woff2|ttf|eot|svg|png|jpg|gif|ico)(\\\\?\\\\w+)?$/",
+        "type": "asset/resource"
+      }
+    ]
+  },
+  "optimization": {
+    "minimize": true,
+    "minimizer": [
+      "[TerserPlugin]"
+    ],
+    "splitChunks": {
+      "automaticNameDelimiter": ".",
+      "chunks": "all"
+    }
+  },
+  "output": {
+    "assetModuleFilename": "assets/static/[name].[hash:8][ext][query]",
+    "chunkFilename": "assets/js/[id].[chunkhash:8].js",
+    "filename": "assets/js/[name].[chunkhash:8].js",
+    "path": "<root>/dist",
+    "publicPath": "/"
+  },
+  "plugins": [
+    "[ESLintWebpackPlugin]",
+    "[ProgressPlugin]",
+    "[CleanWebpackPlugin]",
+    "[ProvidePlugin]",
+    "[DefinePlugin]",
+    "[HtmlWebpackPlugin]",
+    "[MiniCssExtractPlugin]"
+  ],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    },
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".ts",
+      ".tsx"
+    ]
+  },
+  "target": "web"
+}
+`;
+
+exports[`snapshot: default development config 1`] = `
+{
+  "cache": {
+    "cacheDirectory": "<root>/node_modules/.cache/webpack",
+    "type": "filesystem"
+  },
+  "devServer": {
+    "compress": true,
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "hot": true,
+    "port": 9000
+  },
+  "devtool": "eval-cheap-module-source-map",
+  "entry": {
+    "main": "./src/index.js"
+  },
+  "externals": {},
+  "mode": "development",
+  "module": {
+    "rules": [
+      {
+        "exclude": "/node_modules/",
+        "loader": "ts-loader",
+        "options": {
+          "configFile": "<root>/tsconfig.json",
+          "experimentalWatchApi": true,
+          "transpileOnly": true
+        },
+        "test": "/\\\\.tsx?$/"
+      },
+      {
+        "exclude": "/node_modules/",
+        "test": "/\\\\.jsx?$/",
+        "use": {
+          "loader": "babel-loader",
+          "options": {
+            "cacheCompression": false,
+            "cacheDirectory": true,
+            "only": [
+              "src"
+            ],
+            "plugins": [
+              "@babel/plugin-transform-class-properties",
+              "@babel/plugin-transform-object-rest-spread"
+            ],
+            "presets": [
+              [
+                "@babel/env",
+                {
+                  "targets": "> 0.25%, not dead"
+                }
+              ],
+              "@babel/react"
+            ]
+          }
+        }
+      },
+      {
+        "loader": "node-loader",
+        "test": "/\\\\.node$/"
+      },
+      {
+        "test": "/\\\\.(css|s[ac]ss)$/i",
+        "use": [
+          {
+            "loader": "<repo>/node_modules/mini-css-extract-plugin/dist/loader.js"
+          },
+          "css-loader",
+          "sass-loader"
+        ]
+      },
+      {
+        "test": "/\\\\.(woff|woff2|ttf|eot|svg|png|jpg|gif|ico)(\\\\?\\\\w+)?$/",
+        "type": "asset/resource"
+      }
+    ]
+  },
+  "optimization": {
+    "minimize": false,
+    "minimizer": [
+      "[TerserPlugin]"
+    ],
+    "splitChunks": {
+      "automaticNameDelimiter": ".",
+      "chunks": "all"
+    }
+  },
+  "output": {
+    "assetModuleFilename": "assets/static/[name][ext][query]",
+    "chunkFilename": "assets/js/[id].js",
+    "filename": "assets/js/[name].js",
+    "path": "<root>/dist",
+    "publicPath": "/"
+  },
+  "plugins": [
+    "[ESLintWebpackPlugin]",
+    "[ProgressPlugin]",
+    "[CleanWebpackPlugin]",
+    "[ForkTsCheckerWebpackPlugin]",
+    "[ProvidePlugin]",
+    "[DefinePlugin]",
+    "[HtmlWebpackPlugin]",
+    "[MiniCssExtractPlugin]"
+  ],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    },
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".ts",
+      ".tsx"
+    ]
+  },
+  "target": "web"
+}
+`;
+
+exports[`snapshot: default production config 1`] = `
+{
+  "cache": {
+    "cacheDirectory": "<root>/node_modules/.cache/webpack",
+    "type": "filesystem"
+  },
+  "devServer": {
+    "compress": true,
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "hot": true,
+    "port": 9000
+  },
+  "entry": {
+    "main": "./src/index.js"
+  },
+  "externals": {},
+  "mode": "production",
+  "module": {
+    "rules": [
+      {
+        "exclude": "/node_modules/",
+        "loader": "ts-loader",
+        "options": {
+          "configFile": "<root>/tsconfig.json",
+          "experimentalWatchApi": true,
+          "transpileOnly": true
+        },
+        "test": "/\\\\.tsx?$/"
+      },
+      {
+        "exclude": "/node_modules/",
+        "test": "/\\\\.jsx?$/",
+        "use": {
+          "loader": "babel-loader",
+          "options": {
+            "cacheCompression": false,
+            "cacheDirectory": true,
+            "only": [
+              "src"
+            ],
+            "plugins": [
+              "@babel/plugin-transform-class-properties",
+              "@babel/plugin-transform-object-rest-spread"
+            ],
+            "presets": [
+              [
+                "@babel/env",
+                {
+                  "targets": "> 0.25%, not dead"
+                }
+              ],
+              "@babel/react"
+            ]
+          }
+        }
+      },
+      {
+        "loader": "node-loader",
+        "test": "/\\\\.node$/"
+      },
+      {
+        "test": "/\\\\.(css|s[ac]ss)$/i",
+        "use": [
+          {
+            "loader": "<repo>/node_modules/mini-css-extract-plugin/dist/loader.js"
+          },
+          "css-loader",
+          "sass-loader"
+        ]
+      },
+      {
+        "test": "/\\\\.(woff|woff2|ttf|eot|svg|png|jpg|gif|ico)(\\\\?\\\\w+)?$/",
+        "type": "asset/resource"
+      }
+    ]
+  },
+  "optimization": {
+    "minimize": true,
+    "minimizer": [
+      "[TerserPlugin]"
+    ],
+    "splitChunks": {
+      "automaticNameDelimiter": ".",
+      "chunks": "all"
+    }
+  },
+  "output": {
+    "assetModuleFilename": "assets/static/[name].[hash:8][ext][query]",
+    "chunkFilename": "assets/js/[id].[chunkhash:8].js",
+    "filename": "assets/js/[name].[chunkhash:8].js",
+    "path": "<root>/dist",
+    "publicPath": "/"
+  },
+  "plugins": [
+    "[ESLintWebpackPlugin]",
+    "[ProgressPlugin]",
+    "[CleanWebpackPlugin]",
+    "[ForkTsCheckerWebpackPlugin]",
+    "[ProvidePlugin]",
+    "[DefinePlugin]",
+    "[HtmlWebpackPlugin]",
+    "[MiniCssExtractPlugin]"
+  ],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    },
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".ts",
+      ".tsx"
+    ]
+  },
+  "target": "web"
+}
+`;
+
+exports[`snapshot: library config 1`] = `
+{
+  "cache": {
+    "cacheDirectory": "<root>/node_modules/.cache/webpack",
+    "type": "filesystem"
+  },
+  "devServer": {
+    "compress": true,
+    "headers": {
+      "Access-Control-Allow-Origin": "*"
+    },
+    "hot": true,
+    "port": 9000
+  },
+  "entry": {
+    "main": "./src/index.js"
+  },
+  "externals": {},
+  "mode": "production",
+  "module": {
+    "rules": [
+      {
+        "exclude": "/node_modules/",
+        "loader": "ts-loader",
+        "options": {
+          "configFile": "<root>/tsconfig.json",
+          "experimentalWatchApi": true,
+          "transpileOnly": true
+        },
+        "test": "/\\\\.tsx?$/"
+      },
+      {
+        "exclude": "/node_modules/",
+        "test": "/\\\\.jsx?$/",
+        "use": {
+          "loader": "babel-loader",
+          "options": {
+            "cacheCompression": false,
+            "cacheDirectory": true,
+            "only": [
+              "src"
+            ],
+            "plugins": [
+              "@babel/plugin-transform-class-properties",
+              "@babel/plugin-transform-object-rest-spread"
+            ],
+            "presets": [
+              [
+                "@babel/env",
+                {
+                  "targets": "> 0.25%, not dead"
+                }
+              ],
+              "@babel/react"
+            ]
+          }
+        }
+      },
+      {
+        "loader": "node-loader",
+        "test": "/\\\\.node$/"
+      },
+      {
+        "test": "/\\\\.(css|s[ac]ss)$/i",
+        "use": [
+          {
+            "loader": "<repo>/node_modules/mini-css-extract-plugin/dist/loader.js"
+          },
+          "css-loader",
+          "sass-loader"
+        ]
+      },
+      {
+        "test": "/\\\\.(woff|woff2|ttf|eot|svg|png|jpg|gif|ico)(\\\\?\\\\w+)?$/",
+        "type": "asset/resource"
+      }
+    ]
+  },
+  "optimization": {
+    "minimize": true,
+    "minimizer": [
+      "[TerserPlugin]"
+    ],
+    "splitChunks": {}
+  },
+  "output": {
+    "assetModuleFilename": "[name][ext][query]",
+    "chunkFilename": "[id].js",
+    "filename": "[name].js",
+    "library": "MyLib",
+    "libraryTarget": "umd",
+    "path": "<root>/dist",
+    "publicPath": "/"
+  },
+  "plugins": [
+    "[ESLintWebpackPlugin]",
+    "[ProgressPlugin]",
+    "[CleanWebpackPlugin]",
+    "[ForkTsCheckerWebpackPlugin]",
+    "[ProvidePlugin]",
+    "[DefinePlugin]",
+    "[MiniCssExtractPlugin]"
+  ],
+  "resolve": {
+    "alias": {
+      "@root": "<root>/src"
+    },
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".ts",
+      ".tsx"
+    ]
+  },
+  "target": "web"
+}
+`;


### PR DESCRIPTION
`@ekz/packer` had no automated tests. CI built and linted, so a regression in option handling could ship unnoticed — and writing the suite immediately turned one up (below).

## The suite

64 tests using Node's built-in runner, so **no test framework is added**. Coverage is every field of `PackerOptions` and `VitePackerOptions` across both modes, the merge behaviour of `resolve.alias` and `devServer.headers` in all three of their shapes, the TypeScript vs JavaScript-only branch, and both tsconfig error paths. `yarn test` now runs in CI.

The suite is not vacuous: mutating `src/` three times (devServer port, eslint's `failOnError` no longer mode-derived, vite css assets misrouted to the static path) produced 5, 2 and 3 failures respectively.

Two design points worth knowing when adding tests:

- **Tests run against the built `dist/`**, which is what users consume, so the script is `yarn build && node --test`. Yarn runs neither `prepare` on workspace install nor `pretest`, so a bare `node --test` would silently pass against a stale build.
- **Snapshots use a normalized projection.** The raw config embeds absolute `INIT_CWD` paths and live plugin instances, so a raw snapshot would differ between a laptop and CI. Options that only exist inside a plugin (`eslint`, `define`, `provide`, `html`) are asserted field by field instead, so a snapshot pins Packer's output rather than a plugin's own defaults.

## The bug it found

`output: { publicPath: '' }` was silently rewritten to `'/'`. Webpack reads `''` as "emit relative asset URLs" — a legitimate, documented value.

The cause: options were merged with a shallow `Object.assign`, and `output` compensated by defaulting each field with `||`, which cannot distinguish *not supplied* from *supplied as falsy*. `output` is now merged with its defaults once, exactly as `assetPaths` already was, and the `||` chain is gone.

The accompanying test fails on the old code and passes on the fix. Shipped as a patch changeset.