### PR TITLE
Align package description and add discoverability keywords/topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/erkez/packer/actions/workflows/release.yml/badge.svg)](https://github.com/erkez/packer/actions/workflows/release.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/erkez/packer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/erkez/packer)
 
-Opinionated bundler config for React applications - Webpack and Vite support.
+Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.
 
 **Documentation:** [packer.ekz.io](https://packer.ekz.io/)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "examples/*",
     "docs"
   ],
-  "description": "Packer",
+  "description": "Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/packages/packer/README.md
+++ b/packages/packer/README.md
@@ -1,6 +1,6 @@
 # Packer
 
-Packer is opinionated bundler configuration that reduces the setup and maintenance needed to create a React application. It supports both Webpack and Vite.
+Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.
 
 **Documentation:** [packer.ekz.io](https://packer.ekz.io/)
 

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ekz/packer",
   "version": "1.0.3",
-  "description": "Packer",
+  "description": "Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.",
+  "keywords": ["react", "webpack", "vite", "bundler", "build-tool", "eslint", "typescript", "config"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Use one consistent description across the root README, package README, both package.json files, and the GitHub repo description
- Add npm keywords and GitHub topics (react, webpack, vite, bundler, build-tool, eslint, typescript) so the package surfaces in npm/GitHub search