### PR TITLE
Add npm badges, OpenSSF Best Practices badge, and a Why Packer comparison doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/erkez/packer/actions/workflows/ci.yml/badge.svg)](https://github.com/erkez/packer/actions/workflows/ci.yml)
 [![Release](https://github.com/erkez/packer/actions/workflows/release.yml/badge.svg)](https://github.com/erkez/packer/actions/workflows/release.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/erkez/packer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/erkez/packer)
+[![npm version](https://img.shields.io/npm/v/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
+[![npm downloads](https://img.shields.io/npm/dm/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
 
 Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/erkez/packer/actions/workflows/ci.yml/badge.svg)](https://github.com/erkez/packer/actions/workflows/ci.yml)
 [![Release](https://github.com/erkez/packer/actions/workflows/release.yml/badge.svg)](https://github.com/erkez/packer/actions/workflows/release.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/erkez/packer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/erkez/packer)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13614/badge)](https://www.bestpractices.dev/projects/13614)
 [![npm version](https://img.shields.io/npm/v/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
 [![npm downloads](https://img.shields.io/npm/dm/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -7,6 +7,8 @@ slug: /
 
 Packer is an opinionated configuration for bundlers that reduces the setup and maintenance required to build a React application. It supports both Webpack and Vite.
 
+See [Why Packer](/docs/why-packer) for how it compares to hand-rolled config, Create React App, and meta-frameworks like Next.js.
+
 ## Features
 
 - Minimum configuration for a React app

--- a/docs/content/why-packer.md
+++ b/docs/content/why-packer.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1.5
+---
+
+# Why Packer
+
+Packer is not a framework. It doesn't own routing, data fetching, or rendering. It's a config layer over Webpack and Vite that gives a React app (or library) sane defaults on day one, while staying out of the way when you need something it doesn't cover.
+
+## vs. hand-rolled Webpack or Vite config
+
+Starting from a blank `webpack.config.js` or `vite.config.js` means wiring up TypeScript, ESLint, a dev server, and asset output yourself. Packer wires these in by default:
+
+- **TypeScript typechecking**, automatically, when a `tsconfig.json` is found — `ts-loader` + ForkTsChecker for Webpack, `vite-plugin-checker` for Vite. Type errors fail the build; the dev server stays non-blocking.
+- **ESLint flat config** out of the box, including a TypeScript-aware config.
+- **Dev server defaults**: port `9000`, hot reload and compression (Webpack), CORS headers, proxy support.
+- **Content-hashed production filenames** and configurable asset path prefixes for JS/CSS/static output.
+- **Webpack optimization defaults** (`splitChunks`, Terser) and, for Vite, `@vitejs/plugin-react` enabled automatically.
+- **Library builds** — `Packer.webpack.createLibraryConfiguration` produces UMD output for publishing a package, not just an app bundle.
+
+None of this is a black box: native options (`plugins`, `loaders`, `define`, `build`, `devServer`, `resolve`, ...) pass straight through and merge with Packer's defaults, so you're never stuck working around the abstraction.
+
+## vs. Create React App
+
+CRA was [officially deprecated in February 2025](https://react.dev/blog/2025/02/14/sunsetting-create-react-app) and has no active maintainers — it still runs, but only in maintenance mode. Packer aims at the same "install it and start building" ergonomics CRA used to offer, but it's actively maintained and lets you pick Webpack or Vite as the underlying bundler.
+
+## vs. Next.js, Remix, and other meta-frameworks
+
+Packer isn't a competitor to these — they bundle routing, SSR/RSC, and deployment opinions that Packer deliberately doesn't touch. Reach for Packer when you're building a plain SPA or a library and want a build tool that stays out of the way, not a framework that decides how your app is structured.
+
+## Get started
+
+See [Installation](/docs/getting-started/installation) to add Packer to a Webpack or Vite project.

--- a/packages/packer/README.md
+++ b/packages/packer/README.md
@@ -1,5 +1,8 @@
 # Packer
 
+[![npm version](https://img.shields.io/npm/v/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
+[![npm downloads](https://img.shields.io/npm/dm/%40ekz%2Fpacker)](https://www.npmjs.com/package/@ekz/packer)
+
 Opinionated Webpack and Vite configuration for React applications, with built-in ESLint and TypeScript support.
 
 **Documentation:** [packer.ekz.io](https://packer.ekz.io/)


### PR DESCRIPTION
## Summary
- Add npm version/downloads badges to both READMEs as social proof for new visitors
- Add a "Why Packer" docs page comparing it to hand-rolled Webpack/Vite config, Create React App (officially deprecated Feb 2025), and meta-frameworks like Next.js/Remix
- Link the new page from the docs intro